### PR TITLE
Allow for optional error argument to be passed to `fail` and `backoff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Sets a limit on the maximum number of backoffs that can be performed before
 a fail event gets emitted and the backoff instance is reset. By default, there
 is no limit on the number of backoffs that can be performed.
 
-#### backoff.backoff()
+#### backoff.backoff([err])
 
 Starts a backoff operation. Will throw an error if a backoff operation is
 already in progress.
@@ -164,6 +164,10 @@ already in progress.
 In practice, this method should be called after a failed attempt to perform a
 sensitive operation (connecting to a database, downloading a resource over the
 network, etc.).
+
+If provided, the error parameter will be emitted as the last argument of the
+`backoff` and `fail` events to let the client know why the backoff operation
+was attempted.
 
 #### backoff.reset()
 
@@ -179,6 +183,7 @@ request to stop any reconnection attempt.
 
 - number: number of backoffs since last reset, starting at 0
 - delay: backoff delay in milliseconds
+- err: `err` parameter which was passed to `backoff()` call, if present
 
 Emitted when a backoff operation is started. Signals to the client how long
 the next backoff delay will be.
@@ -192,6 +197,8 @@ Emitted when a backoff operation is done. Signals that the failing operation
 should be retried.
 
 #### Event: 'fail'
+
+- err: `err` parameter which was passed to `backoff()` call, if present
 
 Emitted when the maximum number of backoffs is reached. This event will only
 be emitted if the client has set a limit on the number of backoffs by calling

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -42,19 +42,20 @@ Backoff.prototype.failAfter = function(maxNumberOfRetry) {
 
 /**
  * Starts a backoff operation.
+ * @param err Optional error the backoff was caused by.
  */
-Backoff.prototype.backoff = function() {
+Backoff.prototype.backoff = function(err) {
     if (this.timeoutID_ !== -1) {
         throw new Error('Backoff in progress.');
     }
 
     if (this.backoffNumber_ === this.maxNumberOfRetry_) {
-        this.emit('fail');
+        this.emit('fail', err);
         this.reset();
     } else {
         this.backoffDelay_ = this.backoffStrategy_.next();
         this.timeoutID_ = setTimeout(this.handlers.backoff, this.backoffDelay_);
-        this.emit('backoff', this.backoffNumber_, this.backoffDelay_);
+        this.emit('backoff', this.backoffNumber_, this.backoffDelay_, err);
     }
 };
 

--- a/lib/function_call.js
+++ b/lib/function_call.js
@@ -175,7 +175,7 @@ FunctionCall.prototype.handleFunctionCallback_ = function() {
     events.EventEmitter.prototype.emit.apply(this, ['callback'].concat(args));
 
     if (args[0]) {
-        this.backoff_.backoff();
+        this.backoff_.backoff(args[0]);
     } else {
         this.doCallback_();
     }
@@ -187,8 +187,12 @@ FunctionCall.prototype.handleFunctionCallback_ = function() {
  * @param delay Backoff delay.
  * @private
  */
-FunctionCall.prototype.handleBackoff_ = function(number, delay) {
-    this.emit('backoff', number, delay);
+FunctionCall.prototype.handleBackoff_ = function(number, delay, err) {
+    if (err) {
+      this.emit('backoff', number, delay, err);
+    } else {
+      this.emit('backoff', number, delay);
+    }
 };
 
 module.exports = FunctionCall;

--- a/tests/backoff.js
+++ b/tests/backoff.js
@@ -69,6 +69,8 @@ exports["Backoff"] = {
     },
 
     "the fail event should be emitted when backoff limit is reached": function(test) {
+        var err = new Error('Fail');
+
         this.backoffStrategy.next.returns(10);
         this.backoff.on('fail', this.spy);
 
@@ -82,8 +84,9 @@ exports["Backoff"] = {
 
         // Failure should occur on the third call, and not before.
         test.ok(!this.spy.calledOnce, 'Fail event shouldn\'t have been emitted.');
-        this.backoff.backoff();
+        this.backoff.backoff(err);
         test.ok(this.spy.calledOnce, 'Fail event should have been emitted.');
+        test.equal(this.spy.getCall(0).args[0], err, 'Error should be passed');
 
         test.done();
     },

--- a/tests/function_call.js
+++ b/tests/function_call.js
@@ -3,6 +3,7 @@
  * Licensed under the MIT license.
  */
 
+var assert = require('assert');
 var events = require('events');
 var sinon = require('sinon');
 var util = require('util');
@@ -255,5 +256,23 @@ exports["FunctionCall"] = {
         test.deepEqual([3, 1234], backoffSpy.firstCall.args,
             'Backoff event should carry current backoff number and delay.');
         test.done();
+    },
+
+    "when error is provided by the function it should be passed to the callback": function (test) {
+        var err = new Error();
+        var call = new FunctionCall(function (callback) {
+          callback(err);
+        }, [], function (err_) {
+          assert.equal(err_, err);
+          test.done();
+        });
+
+        call.failAfter(1);
+
+        call.on('backoff', function (number, delay, err_) {
+          assert.equal(err_, err);
+        });
+
+        call.start();
     }
 };


### PR DESCRIPTION
This way errors can be logged/emitted without additional bookkeeping on
user's side.
