### PR TITLE
added backoff.inProgress()

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ In practice, this method should be called after having successfully completed
 the sensitive operation guarded by the backoff instance or if the client code
 request to stop any reconnection attempt.
 
+#### backoff.inProgress()
+
+Returns a boolean telling if a backoff is already in progress.
+
 #### Event: 'backoff'
 
 - number: number of backoffs since last reset, starting at 0

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -62,4 +62,9 @@ Backoff.prototype.reset = function() {
     this.timeoutID_ = -1;
 };
 
+// Tells whether a backoff is in progress
+Backoff.prototype.inProgress = function() {
+    return this.timeoutID_ !== -1;
+};
+
 module.exports = Backoff;


### PR DESCRIPTION
Sometimes it's useful to find out whether a backoff is in progress.

(For instance and in my particular case, when a queue drains there may or not be a polling backoff in progress. If there is none, I want to activate the backoff.)

Instead of accessing the "private" property `timeoutID_`, this introduces a prototype method for that, properly documented.
