### PR TITLE
Introduced resetInterval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ Sets a limit on the maximum number of backoffs that can be performed before
 a fail event gets emitted and the backoff instance is reset. By default, there
 is no limit on the number of backoffs that can be performed.
 
+#### backoff.resetInterval(intervalMilliseconds)
+
+- intervalMilliseconds: Time after which the backoff strategy will reset
+after a failure.
+
+If the given time has passed between two consecutive calls to
+`backoff`, `reset` will be automatically called before executing the
+second backoff. By default, there is no automatic reset.
+
 #### backoff.backoff([err])
 
 Starts a backoff operation. If provided, the error parameter will be emitted

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -15,6 +15,8 @@ function Backoff(backoffStrategy) {
     this.backoffNumber_ = 0;
     this.backoffDelay_ = 0;
     this.timeoutID_ = -1;
+    this.resetInterval_ = 0;
+    this.previousBackoffTime_ = 0;
 
     this.handlers = {
         backoff: this.onBackoff_.bind(this)
@@ -32,10 +34,31 @@ Backoff.prototype.failAfter = function(maxNumberOfRetry) {
     this.maxNumberOfRetry_ = maxNumberOfRetry;
 };
 
+// Sets a time interval, in milliseconds greater than 0, on how long
+// the backoff strategy should run before being reset.  If more than
+// this time has passed between two `backoff()` calls, the strategy
+// will be reset before executing the second call.
+Backoff.prototype.resetInterval = function(resetInterval) {
+    precond.checkArgument(resetInterval > 0,
+        'Expected a reset interval time greater than 0 but got %s.',
+        resetInterval);
+
+    this.resetInterval_ = resetInterval;
+};
+
 // Starts a backoff operation. Accepts an optional parameter to let the
 // listeners know why the backoff operation was started.
 Backoff.prototype.backoff = function(err) {
     precond.checkState(this.timeoutID_ === -1, 'Backoff in progress.');
+
+    var now = Date.now();
+    if (this.resetInterval_) {
+        var nextReset = this.previousBackoffTime_ + this.resetInterval_;
+        if (now > nextReset) {
+            this.reset();
+        }
+    }
+    this.previousBackoffTime_ = now;
 
     if (this.backoffNumber_ === this.maxNumberOfRetry_) {
         this.emit('fail', err);

--- a/tests/backoff.js
+++ b/tests/backoff.js
@@ -162,5 +162,27 @@ exports["Backoff"] = {
         test.deepEqual(expectedNumbers, actualNumbers,
             'Backoff number should increase from 0 to N - 1.');
         test.done();
+    },
+
+    "backoff reset interval should be greater than 0": function(test) {
+        var backoff = this.backoff;
+        test.throws(function() {
+            backoff.resetInterval(0);
+        }, /greater than 0 but got 0/);
+        test.done();
+    },
+
+    "backoff should be reset after reset interval": function(test) {
+        this.backoffStrategy.next.returns(10);
+
+        this.backoff.resetInterval(5);
+
+        this.backoff.backoff();
+        this.clock.tick(10);
+        this.backoff.backoff();
+
+        test.ok(this.backoffStrategy.reset.calledOnce,
+            'Backoff should have been resetted after time reset interval.');
+        test.done();
     }
 };


### PR DESCRIPTION
I have a use case where I want to apply the backoff strategy to keeping a server process running.  More abstractly, I want to apply the backoff strategy to a long-living object instead of a single operation.

Let's say a problem occurs that causes my process to crash repeatedly but eventually come back up (backing database goes down, disk full, temporary network failure, configuration file syntax error...).  I wish to apply a backoff strategy to the restarting of this service, to avoid it spamming logs, network, CPU, database, etc.  Let's say 1-60 seconds exponential.

I also want the backoff to start from fresh after a period of non-crashing.  I.e. if the database restarts a few days after a previous failure, I want the backoff to start again from 1 second, and not immediately continue at 60 seconds.

I could do this in my own code by keeping track of the Backoff object's events and calling `reset()` after a given timeout, but it seems cleaner and less brittle to allow for this in the backoff library.
