### PR TITLE
Only include necessary files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
     },
     "engines": {
         "node": ">= 0.6"
-    }
+    },
+    "files": [
+        "index.js",
+        "lib"
+    ]
 }


### PR DESCRIPTION
Because size matters (http://www.rudeshko.com/web/2014/05/13/help-people-consume-your-npm-packages.html)
