### PR TITLE
Allow specifying exponential factor

### DIFF
--- a/lib/strategy/exponential.js
+++ b/lib/strategy/exponential.js
@@ -2,6 +2,7 @@
 //      Licensed under the MIT license.
 
 var util = require('util');
+var precond = require('precond');
 
 var BackoffStrategy = require('./strategy');
 
@@ -10,12 +11,23 @@ function ExponentialBackoffStrategy(options) {
     BackoffStrategy.call(this, options);
     this.backoffDelay_ = 0;
     this.nextBackoffDelay_ = this.getInitialDelay();
+
+    if (options && (options.factor || options.factor === 0)) {
+        precond.checkArgument(options.factor > 1,
+            'Exponential factor should be greater than 1 but got %s.',
+            options.factor);
+        this.factor_ = options.factor;
+    } else {
+        this.factor_ = ExponentialBackoffStrategy.DEFAULT_FACTOR;
+    }
 }
 util.inherits(ExponentialBackoffStrategy, BackoffStrategy);
 
+ExponentialBackoffStrategy.DEFAULT_FACTOR = 2;
+
 ExponentialBackoffStrategy.prototype.next_ = function() {
     this.backoffDelay_ = Math.min(this.nextBackoffDelay_, this.getMaxDelay());
-    this.nextBackoffDelay_ = this.backoffDelay_ * 2;
+    this.nextBackoffDelay_ = this.backoffDelay_ * this.factor_;
     return this.backoffDelay_;
 };
 

--- a/tests/exponential_backoff_strategy.js
+++ b/tests/exponential_backoff_strategy.js
@@ -43,5 +43,21 @@ exports["ExponentialBackoffStrategy"] = {
         test.equals(backoffDelay, 10,
             'Strategy should return the initial delay after reset.');
         test.done();
+    },
+
+    "backoff delay factor should be configurable": function (test) {
+        var expectedDelays = [10, 30, 90, 90];
+        var strategy = new ExponentialBackoffStrategy({
+            initialDelay: 10,
+            maxDelay: 90,
+            factor: 3
+        });
+        var actualDelays = expectedDelays.map(function () {
+            return strategy.next();
+        });
+
+        test.deepEqual(expectedDelays, actualDelays,
+            'Generated delays should follow a configurable exponential sequence.');
+        test.done();
     }
 };


### PR DESCRIPTION
Exponential strategy is no longer hard coded to be \* 2.
