### PR TITLE
Add failAfterTime to limit maximum time elapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ Sets a limit on the maximum number of backoffs that can be performed before
 a fail event gets emitted and the backoff instance is reset. By default, there
 is no limit on the number of backoffs that can be performed.
 
+#### backoff.failAfterTime(maxTotalTime)
+
+- maxTotalTime: maximum time (in milliseconds) before the fail event gets
+emitted upon backoff, must be greater than 0
+
+Sets a limit on the maximum amount of time from the start of the first backoff
+before attempting to backoff will emit a fail event and reset the backoff
+instance.  The last backoff before the limit is reached will be truncated to
+avoid exceeding the limit.  By default, there is no time limit.
+
 #### backoff.backoff([err])
 
 Starts a backoff operation. If provided, the error parameter will be emitted

--- a/examples/fail_time.js
+++ b/examples/fail_time.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+var backoff = require('../index');
+
+var testBackoff = backoff.exponential({
+    initialDelay: 10,
+    maxDelay: 1000
+});
+
+testBackoff.failAfterTime(600);
+
+var start;
+testBackoff.on('backoff', function(number, delay) {
+    console.log('Backoff start: ' + number + ' ' + delay + 'ms' +
+                ' (' + (Date.now() - start) + 'ms elapsed)');
+});
+
+var callDelay = 50;
+testBackoff.on('ready', function(number, delay) {
+    console.log('Backoff done: ' + number + ' ' + delay + 'ms' +
+                ' (' + (Date.now() - start) + 'ms elapsed)');
+    setTimeout(function() {
+        console.log('Simulated call delay: ' + callDelay + 'ms' +
+                    ' (' + (Date.now() - start) + 'ms elapsed)');
+        testBackoff.backoff(); // Launch a new backoff.
+    }, callDelay);
+});
+
+testBackoff.on('fail', function() {
+    console.log('Backoff failure.');
+});
+
+start = Date.now();
+testBackoff.backoff();

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -12,7 +12,9 @@ function Backoff(backoffStrategy) {
 
     this.backoffStrategy_ = backoffStrategy;
     this.maxNumberOfRetry_ = -1;
+    this.maxTotalTime_ = Infinity;
     this.backoffNumber_ = 0;
+    this.backoffStart_ = -1;
     this.backoffDelay_ = 0;
     this.timeoutID_ = -1;
 
@@ -32,16 +34,34 @@ Backoff.prototype.failAfter = function(maxNumberOfRetry) {
     this.maxNumberOfRetry_ = maxNumberOfRetry;
 };
 
+// Sets a time limit, in milliseconds, greater than 0, on the maximum time from
+// the first backoff.  A 'fail' event will be emitted when a backoff is
+// attempted after the limit is reached.  The limit may shorten the last
+// backoff before the time limit is reached to avoid exceeding the limit.
+Backoff.prototype.failAfterTime = function(maxTotalTime) {
+    precond.checkArgument(maxTotalTime > 0,
+        'Expected a maximum total time greater than 0 but got %s.',
+        maxTotalTime);
+
+    this.maxTotalTime_ = maxTotalTime;
+};
+
 // Starts a backoff operation. Accepts an optional parameter to let the
 // listeners know why the backoff operation was started.
 Backoff.prototype.backoff = function(err) {
     precond.checkState(this.timeoutID_ === -1, 'Backoff in progress.');
 
-    if (this.backoffNumber_ === this.maxNumberOfRetry_) {
+    var now = Date.now();
+    if (this.backoffStart_ === -1) {
+        this.backoffStart_ = now;
+    }
+
+    var timeLeft = this.maxTotalTime_ - (now - this.backoffStart_);
+    if (this.backoffNumber_ === this.maxNumberOfRetry_ || timeLeft <= 0) {
         this.emit('fail', err);
         this.reset();
     } else {
-        this.backoffDelay_ = this.backoffStrategy_.next();
+        this.backoffDelay_ = Math.min(this.backoffStrategy_.next(), timeLeft);
         this.timeoutID_ = setTimeout(this.handlers.backoff, this.backoffDelay_);
         this.emit('backoff', this.backoffNumber_, this.backoffDelay_, err);
     }
@@ -57,6 +77,7 @@ Backoff.prototype.onBackoff_ = function() {
 // Stops any backoff operation and resets the backoff delay to its inital value.
 Backoff.prototype.reset = function() {
     this.backoffNumber_ = 0;
+    this.backoffStart_ = -1;
     this.backoffStrategy_.reset();
     clearTimeout(this.timeoutID_);
     this.timeoutID_ = -1;

--- a/lib/function_call.js
+++ b/lib/function_call.js
@@ -25,6 +25,7 @@ function FunctionCall(fn, args, callback) {
     this.backoff_ = null;
     this.strategy_ = null;
     this.failAfter_ = -1;
+    this.failAfterTime_ = -1;
     this.retryPredicate_ = FunctionCall.DEFAULT_RETRY_PREDICATE_;
 
     this.state_ = FunctionCall.State_.PENDING;
@@ -105,6 +106,13 @@ FunctionCall.prototype.failAfter = function(maxNumberOfRetry) {
     return this; // Return this for chaining.
 };
 
+// Sets the backoff time limit.
+FunctionCall.prototype.failAfterTime = function(maxTotalTime) {
+    precond.checkState(this.isPending(), 'FunctionCall in progress.');
+    this.failAfterTime_ = maxTotalTime;
+    return this; // Return this for chaining.
+};
+
 // Aborts the call.
 FunctionCall.prototype.abort = function() {
     if (this.isCompleted() || this.isAborted()) {
@@ -139,6 +147,9 @@ FunctionCall.prototype.start = function(backoffFactory) {
 
     if (this.failAfter_ > 0) {
         this.backoff_.failAfter(this.failAfter_);
+    }
+    if (this.failAfterTime_ > 0) {
+        this.backoff_.failAfterTime(this.failAfterTime_);
     }
 
     this.state_ = FunctionCall.State_.RUNNING;

--- a/tests/function_call.js
+++ b/tests/function_call.js
@@ -16,6 +16,7 @@ function MockBackoff() {
     this.reset = sinon.spy();
     this.backoff = sinon.spy();
     this.failAfter = sinon.spy();
+    this.failAfterTime = sinon.spy();
 }
 util.inherits(MockBackoff, events.EventEmitter);
 
@@ -154,6 +155,33 @@ exports["FunctionCall"] = {
         call.start(this.backoffFactory);
         test.throws(function() {
             call.failAfter(1234);
+        }, /in progress/);
+        test.done();
+    },
+
+    "failAfterTime should not be set by default": function(test) {
+        var call = new FunctionCall(this.wrappedFn, [], this.callback);
+            call.start(this.backoffFactory);
+            test.equal(0, this.backoff.failAfterTime.callCount);
+        test.done();
+    },
+
+    "failAfterTime should be used as the maximum time": function(test) {
+        var failAfterTimeValue = 99;
+        var call = new FunctionCall(this.wrappedFn, [], this.callback);
+        call.failAfterTime(failAfterTimeValue);
+        call.start(this.backoffFactory);
+        test.ok(this.backoff.failAfterTime.calledWith(failAfterTimeValue),
+            'User defined maximum time shoud be ' +
+            'used to configure the backoff instance.');
+        test.done();
+    },
+
+    "failAfterTime should throw if the call is in progress": function(test) {
+        var call = new FunctionCall(this.wrappedFn, [], this.callback);
+        call.start(this.backoffFactory);
+        test.throws(function() {
+            call.failAfterTime(1234);
         }, /in progress/);
         test.done();
     },


### PR DESCRIPTION
This commit adds a `failAfterTime` method to `Backoff` (and `FunctionCall`) to allow limiting the total elapsed time.  The primary intended use case is when the caller has a deadline which can not be exceeded during which to retry an operation with backoff and the number of backoffs can not be
calculated in advance (e.g. because the operation takes a variable amount of time).  In my current use case, this is calling a REST API using backoff up to a deadline.

Thanks for considering,
Kevin