### PR TITLE
Use inherits module for smaller bundle size

### DIFF
--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -3,7 +3,7 @@
 
 var events = require('events');
 var precond = require('precond');
-var util = require('util');
+var inherits = require('inherits');
 
 // A class to hold the state of a backoff operation. Accepts a backoff strategy
 // to generate the backoff delays.
@@ -20,7 +20,7 @@ function Backoff(backoffStrategy) {
         backoff: this.onBackoff_.bind(this)
     };
 }
-util.inherits(Backoff, events.EventEmitter);
+inherits(Backoff, events.EventEmitter);
 
 // Sets a limit, greater than 0, on the maximum number of backoffs. A 'fail'
 // event will be emitted when the limit is reached.

--- a/lib/function_call.js
+++ b/lib/function_call.js
@@ -3,7 +3,7 @@
 
 var events = require('events');
 var precond = require('precond');
-var util = require('util');
+var inherits = require('inherits');
 
 var Backoff = require('./backoff');
 var FibonacciBackoffStrategy = require('./strategy/fibonacci');
@@ -29,7 +29,7 @@ function FunctionCall(fn, args, callback) {
 
     this.state_ = FunctionCall.State_.PENDING;
 }
-util.inherits(FunctionCall, events.EventEmitter);
+inherits(FunctionCall, events.EventEmitter);
 
 // States in which the call can be.
 FunctionCall.State_ = {

--- a/lib/strategy/exponential.js
+++ b/lib/strategy/exponential.js
@@ -1,7 +1,7 @@
 //      Copyright (c) 2012 Mathieu Turcotte
 //      Licensed under the MIT license.
 
-var util = require('util');
+var inherits = require('inherits');
 var precond = require('precond');
 
 var BackoffStrategy = require('./strategy');
@@ -20,7 +20,7 @@ function ExponentialBackoffStrategy(options) {
         this.factor_ = options.factor;
     }
 }
-util.inherits(ExponentialBackoffStrategy, BackoffStrategy);
+inherits(ExponentialBackoffStrategy, BackoffStrategy);
 
 // Default multiplication factor used to compute the next backoff delay from
 // the current one. The value can be overridden by passing a custom factor as

--- a/lib/strategy/fibonacci.js
+++ b/lib/strategy/fibonacci.js
@@ -1,7 +1,7 @@
 //      Copyright (c) 2012 Mathieu Turcotte
 //      Licensed under the MIT license.
 
-var util = require('util');
+var inherits = require('inherits');
 
 var BackoffStrategy = require('./strategy');
 
@@ -11,7 +11,7 @@ function FibonacciBackoffStrategy(options) {
     this.backoffDelay_ = 0;
     this.nextBackoffDelay_ = this.getInitialDelay();
 }
-util.inherits(FibonacciBackoffStrategy, BackoffStrategy);
+inherits(FibonacciBackoffStrategy, BackoffStrategy);
 
 FibonacciBackoffStrategy.prototype.next_ = function() {
     var backoffDelay = Math.min(this.nextBackoffDelay_, this.getMaxDelay());

--- a/lib/strategy/strategy.js
+++ b/lib/strategy/strategy.js
@@ -2,7 +2,6 @@
 //      Licensed under the MIT license.
 
 var events = require('events');
-var util = require('util');
 
 function isDef(value) {
     return value !== undefined && value !== null;

--- a/package.json
+++ b/package.json
@@ -1,32 +1,38 @@
 {
-    "name": "backoff",
-    "description": "Fibonacci and exponential backoffs.",
-    "version": "2.5.0",
-    "license": "MIT",
-    "author": "Mathieu Turcotte <turcotte.mat@gmail.com>",
-    "keywords": ["backoff", "retry", "fibonacci", "exponential"],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/MathieuTurcotte/node-backoff.git"
-    },
-    "dependencies": {
-        "precond": "0.2"
-    },
-    "devDependencies": {
-        "sinon": "1.10",
-        "nodeunit": "0.9"
-    },
-    "scripts": {
-        "docco" : "docco lib/*.js lib/strategy/* index.js",
-        "pretest": "jshint lib/ tests/ examples/ index.js",
-        "test": "node_modules/nodeunit/bin/nodeunit tests/"
-    },
-    "engines": {
-        "node": ">= 0.6"
-    },
-    "files": [
-        "index.js",
-        "lib",
-        "tests"
-    ]
+  "name": "backoff",
+  "description": "Fibonacci and exponential backoffs.",
+  "version": "2.5.0",
+  "license": "MIT",
+  "author": "Mathieu Turcotte <turcotte.mat@gmail.com>",
+  "keywords": [
+    "backoff",
+    "retry",
+    "fibonacci",
+    "exponential"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MathieuTurcotte/node-backoff.git"
+  },
+  "dependencies": {
+    "inherits": "^2.0.3",
+    "precond": "0.2"
+  },
+  "devDependencies": {
+    "sinon": "1.10",
+    "nodeunit": "0.9"
+  },
+  "scripts": {
+    "docco": "docco lib/*.js lib/strategy/* index.js",
+    "pretest": "jshint lib/ tests/ examples/ index.js",
+    "test": "node_modules/nodeunit/bin/nodeunit tests/"
+  },
+  "engines": {
+    "node": ">= 0.6"
+  },
+  "files": [
+    "index.js",
+    "lib",
+    "tests"
+  ]
 }


### PR DESCRIPTION
In combination with https://github.com/MathieuTurcotte/node-precond/pull/5, this reduces the browser bundle size from 21170 bytes to 13537 bytes, saving **7.63kB** or **36%** of the total size.